### PR TITLE
chore: update README to mention this fork is no longer needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 > [!IMPORTANT]
-> This is a fork of the original `solana-sdk` repository that was used to make the code run in non-browser WASM environments, 
+> This is a fork of the original `solana-sdk` repository that was used to make the code run in non-browser WASM environments,
 > such as a canister running on the [Internet Computer](https://internetcomputer.org) (ICP).
-> This fork is not longer required since the relase of [v3.0.0](https://github.com/anza-xyz/solana-sdk/releases/tag/sdk%40v3.0.0). 
+> This fork is not longer required since the relase of [v3.0.0](https://github.com/anza-xyz/solana-sdk/releases/tag/sdk%40v3.0.0).
 > The [original repository]((https://github.com/anza-xyz/solana-sdk) should now be used instead of this fork.
 
 [![Solana crate](https://img.shields.io/crates/v/solana-sdk.svg)](https://crates.io/crates/solana-sdk)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> [!IMPORTANT]
+> This is a fork of the original `solana-sdk` repository that was used to make the code run in non-browser WASM environments, 
+> such as a canister running on the [Internet Computer](https://internetcomputer.org) (ICP).
+> This fork is not longer required since the relase of [v3.0.0](https://github.com/anza-xyz/solana-sdk/releases/tag/sdk%40v3.0.0). 
+> The [original repository]((https://github.com/anza-xyz/solana-sdk) should now be used instead of this fork.
+
 [![Solana crate](https://img.shields.io/crates/v/solana-sdk.svg)](https://crates.io/crates/solana-sdk)
 [![Solana documentation](https://docs.rs/solana-sdk/badge.svg)](https://docs.rs/solana-sdk)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 > This is a fork of the original `solana-sdk` repository that was used to make the code run in non-browser WASM environments,
 > such as a canister running on the [Internet Computer](https://internetcomputer.org) (ICP).
 > This fork is not longer required since the relase of [v3.0.0](https://github.com/anza-xyz/solana-sdk/releases/tag/sdk%40v3.0.0).
-> The [original repository]((https://github.com/anza-xyz/solana-sdk) should now be used instead of this fork.
+> The [original repository](https://github.com/anza-xyz/solana-sdk) should now be used instead of this fork.
 
 [![Solana crate](https://img.shields.io/crates/v/solana-sdk.svg)](https://crates.io/crates/solana-sdk)
 [![Solana documentation](https://docs.rs/solana-sdk/badge.svg)](https://docs.rs/solana-sdk)


### PR DESCRIPTION
([DEFI-2469](https://dfinity.atlassian.net/browse/DEFI-2469)) Update the README to mention this fork is no longer needed and the original repository should be used instead.

[DEFI-2469]: https://dfinity.atlassian.net/browse/DEFI-2469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ